### PR TITLE
Fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ Example configs:
 - [Example 1](src/examples/build-test-deploy.yml) - Build, test and deploy using [edeliver](https://github.com/edeliver/edeliver).
 - [Example 2](src/examples/build-test-with-fakes3.yml) - Build and test with FakeS3.
 - [Example 3](src/examples/build-test-minimal.yml) - Build and test with `build-and-test` job.
+
+## Repo Maintainers
+
+If `dev:alpha` expires, please create a new version using the following commands:
+
+```
+circleci config pack src/ > packed/orb.yml
+circleci orb validate packed/orb.yml                              
+circleci orb publish packed/orb.yml coletiv/elixir@dev:alpha
+```

--- a/src/examples/build-test-deploy.yml
+++ b/src/examples/build-test-deploy.yml
@@ -29,8 +29,8 @@ usage:
               - elixir/build-and-test
             filters:
               branches:
-                ignore:
-                  - master
+                only:
+                  - develop
 
     build-deploy-prod:
       jobs:

--- a/src/examples/build-test-minimal.yml
+++ b/src/examples/build-test-minimal.yml
@@ -2,7 +2,7 @@ description: "Build and test with the minimal configuration an Elixir project"
 usage:
   version: 2.1
   orbs:
-    elixir: coletiv/elixir@0.0.22
+    elixir: coletiv/elixir@0.1.0
   workflows:
     elixir-build-test-minimal:
       jobs:

--- a/src/examples/build-test-with-fakes3.yml
+++ b/src/examples/build-test-with-fakes3.yml
@@ -1,7 +1,7 @@
 description: "Build and test Elixir source code with FakeS3"
 usage:
   orbs:
-    elixir: coletiv/elixir@0.0.22
+    elixir: coletiv/elixir@0.1.0
 
   executors:
     default:


### PR DESCRIPTION
Fix deploy examples, update version to 0.1.0, and add what commands should be executed when dev:alpha expires.